### PR TITLE
Fix for 192

### DIFF
--- a/lib/utility_belt.rb
+++ b/lib/utility_belt.rb
@@ -12,7 +12,7 @@ if Object.const_defined? :IRB
   # Called when the irb session is ready, after any external libraries have been loaded. This
   # allows the user to specify which gadgets in the utility belt to equip. (Kind of pushing the
   # metaphor, but hey, what the hell.)
-  IRB.conf[:IRB_RC] = lambda do
+  IRB.conf[:IRB_RC] = lambda do |throw_away_context|
     UtilityBelt.equip(:defaults) unless UtilityBelt.equipped?
     UTILITY_BELT_IRB_STARTUP_PROCS.each {|symbol, proc| proc.call}
   end


### PR DESCRIPTION
hey Giles,

It looks like ruby 1.9 passes a context object to the lambda in IRB.conf[:IRB_RC] and given it didn't accept any args, boom goes the dynamite. 

So, simple patch to accept it and not do shit with it. Seems to work in 1.9.1 and 1.9.2 while not breaking 1.8.7. 

jack
